### PR TITLE
Add structural cash-flow projection from Contracts

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,9 +2,10 @@ module Main where
 
 import Prelude hiding (until)
 import Contracts (Contract (..), Currency (..), Asset (..), Stock (..), one, until, at)
+import Cashflows (cashflows, renderCashFlows)
 import Control.Monad (unless)
 import Data.List (intercalate)
-import Derivatives (american, european, OptionKind (..))
+import Derivatives (american, european, down_and_in, OptionKind (..))
 import Models (ModelChoice (..), priceWith, defaultMarket, greeksWith, runFutT)
 import System.Environment (getArgs)
 import System.Exit (die)
@@ -20,13 +21,45 @@ parseModel "lsmc" = Just LSMC
 parseModel "lattice" = Just Lattice
 parseModel _      = Nothing
 
--- | main: some examples for now
+-- | The example contracts, each with a heading, shared by the pricing and
+-- cash-flow projection modes.
+examples :: [(String, Contract)]
+examples =
+  [ ("European Call on X",  european Call 1 10.0 CHF (one (Stk X)))
+  , ("European Put on X",   european Put  1 14.0 CHF (one (Stk X)))
+  , ("American Put on X",   american Put (0, 1) 100.0 CHF (one (Stk X)))
+  , ("Down-and-in Put on X (barrier 90)",
+       down_and_in 90.0 (one (Stk X)) (european Put 1 100.0 CHF (one (Stk X))))
+  , ("One share of X",      one (Stk X))
+  , ("Knock-out share of X", until (at 1) (one (Stk X)))
+  ]
+
+heading :: String -> IO ()
+heading t = putStrLn $ "=================== " ++ t ++ " ==================="
+
 main :: IO ()
 main = do
   args <- getArgs
-  model <- case args of
-    [name] | Just m <- parseModel name -> pure m
-    _ -> die "usage: models <bs|crr|jr|jrrn|tian|mc|lsmc|lattice>"
+  case args of
+    ["--cashflows"] -> runCashflows
+    [name] | Just m <- parseModel name -> runPricing m
+    _ -> die "usage: models <bs|crr|jr|jrrn|tian|mc|lsmc|lattice> | --cashflows"
+
+-- | Project and print the contractual cash-flows of each example. Purely
+-- structural: no model and no market data are involved.
+runCashflows :: IO ()
+runCashflows =
+  mapM_ projection examples
+  where
+    projection (title, con) = do
+      heading title
+      print con
+      putStrLn $ renderCashFlows (cashflows con)
+      putStrLn ""
+
+-- | Price (and, for vanillas, show greeks of) each example with the chosen model.
+runPricing :: ModelChoice -> IO ()
+runPricing model = do
   putStrLn $ "Using model: " ++ show model
 
   -- priceWith values the contract with the chosen model: a vanilla European
@@ -34,35 +67,17 @@ main = do
   -- lattice value process (evalC threaded through Futhark).
   let value con = runFutT (priceWith (Cur CHF) model defaultMarket con)
 
-  putStrLn "=================== European Call on X ==================="
-  let euCallOnX = european Call 1 10.0 CHF (one (Stk X)) :: Contract
-  print euCallOnX
-  value euCallOnX >>= \r -> putStrLn $ "Value: " ++ show r   -- when -> disc
+  mapM_ (priceOne model value) examples
 
-  greeks <- runFutT (greeksWith model defaultMarket euCallOnX)
+-- | Price one example and, where the model supplies them (vanilla europeans),
+-- print its greeks. 'greeksWith' returns @[]@ for contracts it does not cover.
+priceOne :: ModelChoice -> (Contract -> IO Double) -> (String, Contract) -> IO ()
+priceOne model value (title, con) = do
+  heading title
+  print con
+  value con >>= \r -> putStrLn $ "Value: " ++ show r
+
+  greeks <- runFutT (greeksWith model defaultMarket con)
   unless (null greeks) $
     putStrLn $ "Greeks (AD): "
             ++ intercalate ", " [name ++ " = " ++ show v | (name, v) <- greeks]
-
-  putStrLn "=================== European Put on X ==================="
-  let euPutOnX = european Put 1 14.0 CHF (one (Stk X)) :: Contract
-  print euPutOnX
-  value euPutOnX >>= \r -> putStrLn $ "Value: " ++ show r
-
-  putStrLn "=================== American Put on X ==================="
-  -- anytime -> snell (the lattice Snell envelope, early exercise)
-  let amPutOnX = american Put (0, 1) 100.0 CHF (one (Stk X))
-  print amPutOnX
-  value amPutOnX >>= \r -> putStrLn $ "Value: " ++ show r
-
-  putStrLn "=================== One share of X (exch) ==================="
-  -- one -> exch (the spot value of the asset)
-  value (one (Stk X)) >>= \r -> putStrLn $ "Value: " ++ show r
-
-  putStrLn "=================== Knock-out share of X (absorb) ==================="
-  -- until -> absorb (the knock-out operator)
-  let koShareOfX = until (at 1) (one (Stk X))
-  print koShareOfX
-  value koShareOfX >>= \r -> putStrLn $ "Value: " ++ show r
-
-  return ()

--- a/financial-contracts.cabal
+++ b/financial-contracts.cabal
@@ -22,7 +22,8 @@ library
   hs-source-dirs:      src
   c-sources:           src/Models/Models.c
   default-extensions:  EmptyDataDecls
-  exposed-modules:     Contracts
+  exposed-modules:     Cashflows
+                     , Contracts
                      , Derivatives
                      , Models
                      , Models.Futhark
@@ -67,3 +68,11 @@ test-suite model-tests
                      , base >=4.11 && <5
                      , erf
                      , massiv
+
+-- Pure structural cash-flow projection; no Futhark dependency.
+test-suite cashflow-tests
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             CashflowTests.hs
+  build-depends:       financial-contracts
+                     , base >=4.11 && <5

--- a/src/Cashflows.hs
+++ b/src/Cashflows.hs
@@ -1,0 +1,194 @@
+{-# LANGUAGE GADTs, OverloadedStrings #-}
+
+-- | Projected cash-flows from a 'Contract'.
+--
+-- This is a purely /structural/ projection: a fold over the contract syntax
+-- (a sibling of 'Valuation.evalC', but where 'evalC' collapses the contract
+-- into a value process, this enumerates the contractual payments). It needs no
+-- market data and no pricing model. Amounts and conditions that depend on
+-- observables are kept symbolically as 'Obs' expressions.
+--
+-- The projection enumerates /all/ branches: an 'Or' or 'Anytime' is a choice
+-- for the holder, so every alternative flow is emitted, tagged (via 'cfChoices')
+-- with the selection that leads to it. A 'Cond' emits both arms, each guarded
+-- by the (negated) condition. The caller decides which branch is realised.
+--
+-- Caveats, all driven by keeping the projection model-free:
+--
+--   * 'When' gates: a temporal gate (at/after/before/between) fixes the
+--     settlement time, with the innermost winning when nested (we do not
+--     intersect windows symbolically); a non-temporal gate, e.g. a barrier
+--     @value u %< b@, is recorded as a guard so it survives an inner temporal
+--     gate (as in a down-and-in barrier option).
+--   * 'Until' (knock-out) is recorded as a guard @not o@ on the inner flows
+--     rather than a true absorbing barrier.
+--   * 'Anytime' settlement is reported as the exercise /window/; the actual
+--     exercise date is the holder's (model-dependent) choice.
+module Cashflows
+  ( CashFlow (..)
+  , TimeSpec (..)
+  , cashflows
+  , renderCashFlows
+  ) where
+
+import Prelude hiding (until)
+import Contracts
+import Data.List (intercalate)
+
+-- | When a projected flow settles, as far as it can be read off the gating
+-- observable without a model.
+data TimeSpec
+  = Now                 -- ^ acquired immediately (no enclosing temporal gate)
+  | OnDate Time         -- ^ exactly at @t@           (@when (at t)@)
+  | InWindow Time Time  -- ^ any time in @[t1,t2]@     (@anytime (between t1 t2)@)
+  | FromDate Time       -- ^ at or after @t@           (@when (after t)@)
+  | UntilDate Time      -- ^ before @t@                (@when (before t)@)
+  | WhenObs (Obs Bool)  -- ^ gated by a non-temporal observable we could not reduce
+  deriving Show
+
+-- | A single projected payment.
+data CashFlow = CashFlow
+  { cfTime    :: TimeSpec    -- ^ when the payment settles
+  , cfAsset   :: Asset       -- ^ the asset paid or received
+  , cfAmount  :: Obs Double  -- ^ symbolic amount (product of enclosing scales); @konst 1@ if unscaled
+  , cfSign    :: Double      -- ^ @+1@ received (long) / @-1@ paid (after an odd number of 'Give's)
+  , cfGuards  :: [Obs Bool]  -- ^ conditions that must all hold for the flow to occur
+  , cfChoices :: [String]    -- ^ optional-branch selections on the path to this flow
+  }
+
+-- | State threaded down the contract tree while projecting.
+data Ctx = Ctx
+  { ctxSign    :: Double
+  , ctxScale   :: Obs Double
+  , ctxTime    :: TimeSpec
+  , ctxGuards  :: [Obs Bool]
+  , ctxChoices :: [String]
+  }
+
+-- | Project the cash-flows of a contract, in structural (pre-order) order.
+cashflows :: Contract -> [CashFlow]
+cashflows = go ctx0
+  where
+    ctx0 = Ctx { ctxSign = 1, ctxScale = konst 1, ctxTime = Now, ctxGuards = [], ctxChoices = [] }
+
+    go :: Ctx -> Contract -> [CashFlow]
+    go ctx c = case c of
+      Zero        -> []
+      One a       -> [ CashFlow (ctxTime ctx) a (ctxScale ctx) (ctxSign ctx)
+                                (ctxGuards ctx) (ctxChoices ctx) ]
+      Give x      -> go ctx { ctxSign = negate (ctxSign ctx) } x
+      And a b     -> go ctx a ++ go ctx b
+      Or a b      -> go (choose "or:left"  ctx) a ++ go (choose "or:right" ctx) b
+      Cond o a b  -> go (guardWith o ctx) a ++ go (guardWith (notObs o) ctx) b
+      Scale o x   -> go ctx { ctxScale = mulObs (ctxScale ctx) o } x
+      When o x    -> go (whenGate o ctx) x
+      Anytime o x -> go (choose ("exercise " ++ showTime (timeOf o)) ctx) { ctxTime = timeOf o } x
+      Until o x   -> go (guardWith (notObs o) ctx) x
+
+    choose tag ctx    = ctx { ctxChoices = ctxChoices ctx ++ [tag] }
+    guardWith o ctx   = ctx { ctxGuards  = ctxGuards ctx ++ [o] }
+
+    -- A temporal gate (at/after/before/between) fixes the settlement time
+    -- (innermost wins); a non-temporal gate -- e.g. a barrier @value u %< b@ --
+    -- is a condition that must hold, recorded as a guard so it survives an
+    -- inner temporal 'When' rather than being silently overwritten.
+    whenGate o ctx = case timeOf o of
+      WhenObs g -> guardWith g ctx
+      spec      -> ctx { ctxTime = spec }
+
+-- | Read a settlement 'TimeSpec' off a gating observable. Recognises the
+-- temporal primitives and the @after t1 && before t2@ window ('between'),
+-- and keeps anything else as a symbolic gate.
+timeOf :: Obs Bool -> TimeSpec
+timeOf o = case o of
+  At t     -> OnDate t
+  After t  -> FromDate t
+  Before t -> UntilDate t
+  Lift2 "(&&)" _ (After t1)  (Before t2) -> InWindow t1 t2
+  Lift2 "(&&)" _ (Before t2) (After t1)  -> InWindow t1 t2
+  _        -> WhenObs o
+
+-- | Logical negation lifted into 'Obs', tagged for display.
+notObs :: Obs Bool -> Obs Bool
+notObs = lift "not" not
+
+-- | Multiply two amount observables, dropping a @konst 1@ identity so that
+-- unscaled flows read as @1.0@ rather than @1.0 * 1.0@.
+mulObs :: Obs Double -> Obs Double -> Obs Double
+mulObs a b
+  | isOne a   = b
+  | isOne b   = a
+  | otherwise = lift2 "(*)" (*) a b
+  where
+    isOne (Konst x) = x == 1
+    isOne _         = False
+
+-- Rendering -----------------------------------------------------------------
+
+-- | A human-readable, one-line-per-flow rendering of a projection, e.g.
+--
+-- > on 1: receive 1.0 × (Stk X)            [or:left]
+-- > on 1: pay     10.0 × (Cur EUR)          [or:left]
+renderCashFlows :: [CashFlow] -> String
+renderCashFlows [] = "(no cash-flows)"
+renderCashFlows cs = intercalate "\n" (map renderCashFlow cs)
+
+renderCashFlow :: CashFlow -> String
+renderCashFlow cf = unwords $
+     [ showTime (cfTime cf) ++ ":"
+     , dir (cfSign cf)
+     , inlineObs (cfAmount cf)
+     , "×"
+     , "(" ++ show (cfAsset cf) ++ ")"
+     ]
+  ++ [ "if " ++ intercalate " ∧ " (map inlineObs (cfGuards cf)) | not (null (cfGuards cf)) ]
+  ++ [ "[" ++ intercalate ", " (cfChoices cf) ++ "]"            | not (null (cfChoices cf)) ]
+  where
+    dir s | s < 0     = "pay    "
+          | otherwise = "receive"
+
+showTime :: TimeSpec -> String
+showTime t = case t of
+  Now          -> "now"
+  OnDate d     -> "on " ++ show d
+  InWindow a b -> "in [" ++ show a ++ ".." ++ show b ++ "]"
+  FromDate d   -> "from " ++ show d
+  UntilDate d  -> "before " ++ show d
+  WhenObs o    -> "when " ++ inlineObs o
+
+-- | Render an observable on a single line, showing lifted binary operators
+-- infix (e.g. @value(one (Stk X)) < 90.0@) and other lifts as prefix
+-- application (e.g. @not at 1@). Composite operands are parenthesised.
+inlineObs :: Obs a -> String
+inlineObs o = case o of
+  Konst a       -> show a
+  At t          -> "at "     ++ show t
+  After t       -> "after "  ++ show t
+  Before t      -> "before " ++ show t
+  Value c       -> "value(" ++ inlineContract c ++ ")"
+  Lift s _ a    -> s ++ " " ++ operand a
+  Lift2 s _ a b -> case stripOp s of
+    Just op -> operand a ++ " " ++ op ++ " " ++ operand b
+    Nothing -> s ++ " " ++ operand a ++ " " ++ operand b
+
+-- | Render a sub-observable as an operand, parenthesising the composite
+-- (lifted) cases so the surrounding operator's structure stays unambiguous.
+operand :: Obs a -> String
+operand o = case o of
+  Lift{}  -> "(" ++ inlineObs o ++ ")"
+  Lift2{} -> "(" ++ inlineObs o ++ ")"
+  _       -> inlineObs o
+
+-- | An operator symbol is tagged in parens (e.g. @"(<)"@, @"(&&)"@); strip
+-- them to recover the infix form. Prefix lifts (@"not"@, @"abs"@) are untagged.
+stripOp :: String -> Maybe String
+stripOp ('(' : rest) | not (null rest), last rest == ')' = Just (init rest)
+stripOp _                                                = Nothing
+
+-- | Collapse a contract's tree rendering onto one line (for @value(...)@).
+inlineContract :: Contract -> String
+inlineContract c = case renderContract c of
+  [single] -> single
+  ls       -> unwords (map (dropWhile isBox) ls)
+  where
+    isBox ch = ch `elem` ("│├└─ " :: String)

--- a/test/CashflowTests.hs
+++ b/test/CashflowTests.hs
@@ -1,0 +1,71 @@
+-- | Golden tests pinning the structural cash-flow projection ('Cashflows')
+-- for the example contracts (the same set as @models --cashflows@), plus a
+-- 'Cond' case exercising both guarded arms and the negated branch condition.
+--
+-- Purely structural: no model and no market data, so this suite is fast and
+-- has no Futhark dependency.
+module Main where
+
+import Prelude hiding (until)
+import Contracts (Currency (..), Asset (..), Stock (..), Contract, one, until, at, cond, times, give)
+import Cashflows (cashflows, renderCashFlows)
+import Control.Monad (unless)
+import Data.List (intercalate)
+import Derivatives (american, european, down_and_in, eur, chf, OptionKind (..))
+import System.Exit (exitFailure)
+
+-- | (label, contract, expected rendering of its projection).
+cases :: [(String, Contract, [String])]
+cases =
+  [ ( "European Call on X"
+    , european Call 1 10.0 CHF (one (Stk X))
+    , [ "on 1: receive 1.0 × (Stk X) [or:left]"
+      , "on 1: pay     10.0 × (Cur CHF) [or:left]" ] )
+
+  , ( "European Put on X"
+    , european Put 1 14.0 CHF (one (Stk X))
+    , [ "on 1: pay     1.0 × (Stk X) [or:left]"
+      , "on 1: receive 14.0 × (Cur CHF) [or:left]" ] )
+
+  , ( "American Put on X"
+    , american Put (0, 1) 100.0 CHF (one (Stk X))
+    , [ "in [0..1]: pay     1.0 × (Stk X) [exercise in [0..1]]"
+      , "in [0..1]: receive 100.0 × (Cur CHF) [exercise in [0..1]]" ] )
+
+  , ( "Down-and-in Put on X (barrier survives inner temporal gate as a guard)"
+    , down_and_in 90.0 (one (Stk X)) (european Put 1 100.0 CHF (one (Stk X)))
+    , [ "on 1: pay     1.0 × (Stk X) if value(one (Stk X)) < 90.0 [or:left]"
+      , "on 1: receive 100.0 × (Cur CHF) if value(one (Stk X)) < 90.0 [or:left]" ] )
+
+  , ( "One share of X"
+    , one (Stk X)
+    , [ "now: receive 1.0 × (Stk X)" ] )
+
+  , ( "Knock-out share of X"
+    , until (at 1) (one (Stk X))
+    , [ "now: receive 1.0 × (Stk X) if not at 1" ] )
+
+  , ( "Conditional (both arms, negated guard)"
+    , cond (at 2) (times 50 eur) (give (times 20 chf))
+    , [ "now: receive 50.0 × (Cur EUR) if at 2"
+      , "now: pay     20.0 × (Cur CHF) if not at 2" ] )
+  ]
+
+main :: IO ()
+main = do
+  oks <- mapM check cases
+  unless (and oks) exitFailure
+
+check :: (String, Contract, [String]) -> IO Bool
+check (name, con, expected) = do
+  let want = intercalate "\n" expected
+      got  = renderCashFlows (cashflows con)
+      ok   = got == want
+  putStrLn $ (if ok then "PASS  " else "FAIL  ") ++ name
+  unless ok $ do
+    putStrLn "  expected:"; putStrLn (indent want)
+    putStrLn "  got:";      putStrLn (indent got)
+  pure ok
+
+indent :: String -> String
+indent = intercalate "\n" . map ("    " ++) . lines


### PR DESCRIPTION
New Cashflows module folds a Contract into a symbolic payment schedule